### PR TITLE
Add apparmor profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ install:
 	install -m755 etc/init.d/reseed ${prefix}etc/init.d/reseed
 	install -g i2psvc -o i2psvc -D -d ${prefix}var/lib/i2p/i2p-config/reseed/
 	install -g i2psvc -o i2psvc -D -d ${prefix}etc/systemd/system/reseed.service.d/
+	install -m644 etc/apparmor.d/usr.bin.reseed-tools ${prefix}etc/apparmor.d/usr.bin.reseed-tools
+	install -m644 etc/apparmor.d/local/usr.bin.reseed-tools ${prefix}etc/apparmor.d/local/usr.bin.reseed-tools
 	install -m644 etc/systemd/system/reseed.service.d/override.conf ${prefix}etc/systemd/system/reseed.service.d/override.conf
 	install -m644 etc/systemd/system/reseed.service ${prefix}etc/systemd/system/reseed.service
 
@@ -58,6 +60,8 @@ uninstall:
 	rm -rf ${prefix}bin/reseed-tools
 	rm -rf ${prefix}etc/default/reseed
 	rm -rf ${prefix}etc/init.d/reseed
+	rm -rf ${prefix}etc/apparmor.d/usr.bin.reseed-tools
+	rm -rf ${prefix}etc/apparmor.d/local/usr.bin.reseed-tools
 	rm -rf ${prefix}etc/systemd/system/reseed.service.d/reseed.conf
 	rm -rf ${prefix}etc/systemd/system/reseed.service
 	rm -rf ${prefix}var/lib/i2p/i2p-config/reseed/

--- a/etc/apparmor.d/local/usr.bin.reseed-tools
+++ b/etc/apparmor.d/local/usr.bin.reseed-tools
@@ -1,0 +1,1 @@
+# Empty, add custom directives here if needed

--- a/etc/apparmor.d/usr.bin.reseed-tools
+++ b/etc/apparmor.d/usr.bin.reseed-tools
@@ -1,0 +1,25 @@
+#include <tunables/global>
+
+profile reseed-tools /usr{,/local}/bin/reseed-tools {
+  #include <abstractions/base>
+
+  network inet stream,
+  network inet6 stream,
+  network unix stream,
+
+  # Allow reading key and certs
+  /usr{,/local}/share/reseed-tools/      r,
+  /usr{,/local}/share/reseed-tools/*.pem r,
+  /usr{,/local}/share/reseed-tools/*.crt r,
+
+  # Default debian location for i2pd
+  /var/lib/i2pd/netDb/   r,
+  /var/lib/i2pd/netDb/** r,
+
+  # Default debian location for i2p
+  /var/lib/i2p/i2p-config/netDb/   r,
+  /var/lib/i2p/i2p-config/netDb/** r,
+
+  #include if exists <local/usr.bin.reseed-tools>
+}
+


### PR DESCRIPTION
Add an apparmor profile. This profile will help ensure that reseed-tools is effectively ran as a read-only service. I've tested this change with an nginx reverse proxy. I've ran this on reseed.onion.im for some time and haven't seen any issues.